### PR TITLE
Potentially fixed the Quick Start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## 🔨 Quickstart
 
 ```elisp
-(use-package sideline-flycheck
+(use-package sideline
   :hook (flycheck-mode . sideline-mode)
   :init
   (setq sideline-backends-right '(sideline-flycheck)))


### PR DESCRIPTION
I assume you wanted first use-package declaration to address sideline, not sideline-flycheck? Because using two use-package declarations for same package can allegedly cause unexpected behaviour, and also the first use-package declaration looks sideline specific, not sideline-flycheck specific.