### PR TITLE
add `sideline-flycheck-show-error-id` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 
 - `sideline-flycheck-display-mode` - Method type to when sideline will display flycheck's errors.
 - `sideline-flycheck-show-checker-name` - If non-nil, show the checker's name at the back.
+- `sideline-flycheck-show-error-id` - If non-nil, append the diagnostic ID (e.g. `reportUnusedExpression`, `E501`) to the error message`.
 - `sideline-flycheck-max-lines` - Maximum number of lines to show.
 
 ## 🛠️ Contribute

--- a/sideline-flycheck.el
+++ b/sideline-flycheck.el
@@ -63,6 +63,15 @@
   :type 'boolean
   :group 'sideline-flycheck)
 
+(defcustom sideline-flycheck-show-error-id nil
+  "If non-nil, append the diagnostic ID to the error message.
+
+For LSP-backed diagnostics this surfaces codes such as
+\"reportUnusedExpression\" or \"E501\" alongside the message,
+formatted via `flycheck-error-format-message-and-id'."
+  :type 'boolean
+  :group 'sideline-flycheck)
+
 (defcustom sideline-flycheck-max-lines 1
   "Maximum number of lines to show."
   :type 'integer
@@ -156,7 +165,9 @@ Argument COMMAND is required in sideline backend."
                            (`warning sideline-flycheck-warning-prefix)
                            (`error   sideline-flycheck-error-prefix)
                            (`info    sideline-flycheck-info-prefix)))
-                 (msg (flycheck-error-message err))
+                 (msg (if sideline-flycheck-show-error-id
+                          (flycheck-error-format-message-and-id err)
+                        (flycheck-error-message err)))
                  (lines (split-string msg "\n"))
                  (lines (butlast lines (- (length lines) sideline-flycheck-max-lines)))
                  (msg (mapconcat #'identity lines "\n"))


### PR DESCRIPTION
## Summary

Add an opt-in `sideline-flycheck-show-error-id` defcustom (default `nil`).
When non-nil, the rendered sideline message is built via
`flycheck-error-format-message-and-id`, so the diagnostic ID is appended
in brackets:

```
Expression value is unused [reportUnusedExpression]
```

instead of the current

```
Expression value is unused
```

The default stays `nil`, so existing users see no change.

## Motivation — companion to lsp-mode#5036

This is the sideline-flycheck companion to
[emacs-lsp/lsp-mode#5036](https://github.com/emacs-lsp/lsp-mode/pull/5036),
which appends the same diagnostic code to `flymake` messages. During the
review of that PR, I stated that flycheck already shows the code, but
you (@jcs090218) showed me a screenshot where no code was visible.

I searched more into it and found that your screenshot was taken in `sideline-flycheck`,
which renders only `flycheck-error-message` and therefore drops the ID even though
`flycheck-error-id` is populated. Previously, I had only tested `lsp-ui-sideline`
which is alternative to this package.

This PR brings sideline-flycheck in line with what flymake will show
once lsp-mode#5036 lands, and matches the way `flycheck-list-errors`
already surfaces the ID column.

## Changes

- New `defcustom sideline-flycheck-show-error-id` (default `nil`).
- Render path conditionally switches between `flycheck-error-message`
  and `flycheck-error-format-message-and-id`.
- `README.md` Variables section lists the new option.

## Test plan

- [x] Default config: sideline output unchanged.
- [x] `(setq sideline-flycheck-show-error-id t)`: ID appears in brackets
  after the message for LSP-backed diagnostics (verified with
  basedpyright on Python).
- [x] Parser-level diagnostics that genuinely carry no ID (e.g. "Statements
  must be separated by newlines or semicolons") render unchanged — no
  trailing brackets, no empty `[]`.
